### PR TITLE
Add oplog proxy support

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	neturl "net/url"
 	"os"
 	"regexp"
 	"strings"
@@ -32,6 +33,8 @@ type Options struct {
 	AllowReplication bool
 	// Password to access password protected oplog
 	Password string
+	// Proxy to be used to access oplog
+	Proxy string
 	// Filters to apply on the oplog output
 	Filter Filter
 }
@@ -109,12 +112,20 @@ func Subscribe(url string, options Options) *Consumer {
 		}
 	}
 
+	var proxyFunc func(*http.Request) (*neturl.URL, error) = nil
+
+	if len(options.Proxy) > 0 {
+		url_proxy, _ := neturl.ParseRequestURI(options.Proxy)
+		proxyFunc = http.ProxyURL(url_proxy)
+	}
+
 	c := &Consumer{
 		url:     strings.Join([]string{url, qs}, ""),
 		options: options,
 		ife:     newInFlightEvents(),
 		mu:      &sync.RWMutex{},
 		ack:     make(chan Operation),
+		http:    http.Client{Transport: &http.Transport{Proxy: proxyFunc}},
 	}
 
 	return c

--- a/consumer.go
+++ b/consumer.go
@@ -113,10 +113,12 @@ func Subscribe(url string, options Options) *Consumer {
 	}
 
 	var proxyFunc func(*http.Request) (*neturl.URL, error) = nil
-
 	if len(options.Proxy) > 0 {
-		url_proxy, _ := neturl.ParseRequestURI(options.Proxy)
-		proxyFunc = http.ProxyURL(url_proxy)
+		urlProxy, err := neturl.Parse(options.Proxy)
+		if err != nil {
+			panic(err)
+		}
+		proxyFunc = http.ProxyURL(urlProxy)
 	}
 
 	c := &Consumer{


### PR DESCRIPTION
Allow oplog consumers to run on servers with no direct internet access through the use of a proxy.
